### PR TITLE
Add theme's license information and a link to the license

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,9 @@ layout: default
 		{% if page.demo %}
 			<a class="btn" href="{{ page.demo }}"><i class="icon-road"></i> Demo</a>
 		{% endif %}
+		{% if page.license_link %}
+			<a class="btn" href="{{ page.license_link }}"><i class="icon-file"></i> License</a>
+		{% endif %}
 	</div>
 
 

--- a/_posts/2013-06-01-scribble.markdown
+++ b/_posts/2013-06-01-scribble.markdown
@@ -8,6 +8,7 @@ demo: http://scribble.muan.co/2013/05/06/scribble-the-jekyll-theme/
 author: Mu-An Chiou
 thumbnail: scribble.png
 license: MIT License
+license_link: https://github.com/muan/scribble/blob/master/LICENCE
 ---
 
 There is no clever design philosophy to talk about, I tried to find something to work with, and ‘scribble’ came to my mind. This theme uses Open Sans powered by Google Web Fonts, and was written in plain HTML, SCSS & CoffeeScript, though .scss & .coffee files wouldn’t be included in the theme.

--- a/_posts/2013-06-05-solar.markdown
+++ b/_posts/2013-06-05-solar.markdown
@@ -8,6 +8,7 @@ demo: http://redwallhp.github.io/solar-theme-jekyll/
 author: Matt Harzewski
 thumbnail: solar.png
 license: GPL v2 or higher
+license_link: https://github.com/redwallhp/solar-theme-jekyll#license
 ---
 
 A stylish theme for Jekyll blogs, based on the Solarized color palette. For installation instructions, please read the README.md [on GitHub!](https://github.com/redwallhp/solar-theme-jekyll)

--- a/_posts/2013-06-15-left.markdown
+++ b/_posts/2013-06-15-left.markdown
@@ -7,6 +7,7 @@ download: https://github.com/holman/left/archive/master.zip
 author: Zach Holman
 thumbnail: left.png
 license: MIT License
+license_link: https://github.com/holman/left/blob/master/LICENSE
 ---
 
 Left is a clean, whitespace-happy layout for Jekyll.

--- a/_posts/2013-06-15-slate.markdown
+++ b/_posts/2013-06-15-slate.markdown
@@ -7,4 +7,5 @@ download: https://github.com/jsncostello/slate/archive/master.zip
 author: Jason Costello
 thumbnail: slate.png
 license: Creative Commons Attribution 3.0 License
+license_link: https://github.com/jsncostello/slate/blob/master/README.md
 ---

--- a/_posts/2013-07-13-so-simple.markdown
+++ b/_posts/2013-07-13-so-simple.markdown
@@ -8,6 +8,7 @@ demo: http://mmistakes.github.io/so-simple-theme/
 author: Michael Rose
 thumbnail: so-simple.png
 license: GPL v2
+license_link: https://github.com/mmistakes/so-simple-theme/blob/master/LICENSE
 ---
 
 A simple and clean responsive Jekyll theme for words and photos.

--- a/_posts/2013-07-19-minimal-mistakes.markdown
+++ b/_posts/2013-07-19-minimal-mistakes.markdown
@@ -8,6 +8,7 @@ demo: http://mmistakes.github.io/minimal-mistakes/
 author: Michael Rose
 thumbnail: minimal-mistakes.png
 license: MIT License
+license_link: https://github.com/mmistakes/minimal-mistakes/blob/master/LICENSE
 ---
 
 A minimal Jekyll theme that is all about:

--- a/_posts/2013-08-06-balzac.markdown
+++ b/_posts/2013-08-06-balzac.markdown
@@ -8,6 +8,7 @@ demo: http://jekyll.gtat.me
 author: Cole Townsend
 thumbnail: Balzac-for-Jekyll-thumb.jpg
 license: MIT License
+license_link: https://github.com/ColeTownsend/Balzac-for-Jekyll/blob/master/LICENSE
 ---
 
 This is built on Semantic.gs grid framework which I edited a bit to make it fluid. It was forked from the wonderful Minimal Mistakes theme by Michael Rose.

--- a/_posts/2013-08-23-lagom.markdown
+++ b/_posts/2013-08-23-lagom.markdown
@@ -7,6 +7,7 @@ download: https://github.com/swanson/lagom/archive/master.zip
 author: Matt Swanson
 thumbnail: lagom.png
 license: MIT License
+license_link: https://github.com/swanson/lagom/blob/master/LICENSE
 ---
 
 Lagom, a [Jekyll][j] blog theme with just the right amount of style. 

--- a/_posts/2013-08-24-hpstr.markdown
+++ b/_posts/2013-08-24-hpstr.markdown
@@ -8,6 +8,7 @@ demo: http://mmistakes.github.io/hpstr-jekyll-theme/
 author: Michael Rose
 thumbnail: hpstr.png
 license: GPL v2
+license_link: https://github.com/mmistakes/hpstr-jekyll-theme/blob/master/LICENSE
 ---
 
 What HPSTR brings to the table:


### PR DESCRIPTION
Now it allows theme creators to specify the license information and add a link to the license.

If the `license` field is present, it will be shown under the "Author", if the `license_link` field is present, a new "License" button will be displayed in the button area (Homepage, Download, Demo, etc.).
