### PR TITLE
Add themes' missing information from their homepages

### DIFF
--- a/_posts/2013-06-02-green-tea.markdown
+++ b/_posts/2013-06-02-green-tea.markdown
@@ -3,7 +3,9 @@ layout: post
 title:  "Green Tea"
 date:   2013-06-02 01:42:00
 homepage: http://richbray.me/frap/
+download: http://richbray.me/frap/gt.zip
 demo: http://richbray.me/frap/gt/
 author: Richard Bray
 thumbnail: green-tea.png
 ---
+A more colourful theme than VBC and a less professional look. Something for the design minded who don't want to spend too much time inking in code. Currently being worked on

--- a/_posts/2013-06-02-vanilla-bean-creme.markdown
+++ b/_posts/2013-06-02-vanilla-bean-creme.markdown
@@ -3,7 +3,9 @@ layout: post
 title:  " Vanilla Bean Creme "
 date:   2013-06-02 01:40:00
 homepage: http://richbray.me/frap/
+download: http://richbray.me/frap/vbc.zip
 demo: http://richbray.me/frap/vbc/
 author: Richard Bray
 thumbnail: vanilla-bean-creme.png
 ---
+VBC is a simple black & white, serif font (Georgia and Noto Serif ) theme with a professional look. Ideal for the programmer who wants to get up and running with a blog just for writing.

--- a/_posts/2013-06-15-slate.markdown
+++ b/_posts/2013-06-15-slate.markdown
@@ -7,3 +7,4 @@ download: https://github.com/jsncostello/slate/archive/master.zip
 author: Jason Costello
 thumbnail: slate.png
 ---
+Slate is responsive theme for GitHub Pages. [Fork it](https://github.com/jsncostello/slate/fork) and use it on your own site or generate one automatically using [GitHub Pages](http://pages.github.com).

--- a/_posts/2013-08-06-balzac.markdown
+++ b/_posts/2013-08-06-balzac.markdown
@@ -9,7 +9,7 @@ author: Cole Townsend
 thumbnail: Balzac-for-Jekyll-thumb.jpg
 ---
 
-This is built on Semantic.gs grid framework which I edited a bit to make it fluid. It was forked from the wonderful Minimal Mistakes theme by Michael Rose.
+This is built on [Semantic.gs](http://semantic.gs/) grid framework which I edited a bit to make it fluid. It was forked from the wonderful [Minimal Mistakes theme](https://github.com/mmistakes/minimal-mistakes) by Michael Rose.
 
 I hope you enjoy using, forking, whatevering this theme as much as I did making it. 
 


### PR DESCRIPTION
Green Tea: add download link and description
Vanilla Bean Creme: add download link and description
Slate: add description
Balzac: add links in the description
