### PR TITLE
Change the URL for the demo site

### DIFF
--- a/_posts/2014-02-08-brume.markdown
+++ b/_posts/2014-02-08-brume.markdown
@@ -4,7 +4,7 @@ title:  "brume"
 date:   2014-02-08 19:17:00
 homepage: https://github.com/aigarsdz/brume
 download: https://github.com/aigarsdz/brume/archive/master.zip
-demo: http://aigarsdz.github.io
+demo: http://aigarsdz.github.io/brume
 author: Aigars Dzerviniks
 thumbnail: brume.png
 license: MIT License


### PR DESCRIPTION
I created a project page for brume, therefore the demo URL should link to that page instead of my blog.
