### PR TITLE
Changing the demo URL from the development to live one!

### DIFF
--- a/_posts/2014-07-29-jekyllmetro.markdown
+++ b/_posts/2014-07-29-jekyllmetro.markdown
@@ -4,7 +4,7 @@ title:  "Jekyll Metro"
 date:   2014-07-29
 homepage: https://github.com/olakara/JekyllMetro
 download: https://github.com/olakara/JekyllMetro/archive/master.zip
-demo: http://blog-olakara.rhcloud.com
+demo: http://abdelraoof.com
 author: Abdel Raoof Olakara
 thumbnail: jekyllmetro.png
 license: MIT


### PR DESCRIPTION
Since the theme is still actively developed, it would be great to have the demo URL point to a live site rather than the development one. There are chances dev site may not be available at all times. Please merge this change with the site.
