### PR TITLE
Removing bad demo link on Squared theme entry.

### DIFF
--- a/_posts/2014-05-02-squared.markdown
+++ b/_posts/2014-05-02-squared.markdown
@@ -3,7 +3,6 @@ layout: post
 title: Squared
 homepage: https://github.com/anandubajith/squared
 download: https://github.com/anandubajith/squared/archive/master.zip
-demo: http://anandu.info/squared
 author: Anandu B Ajith
 thumbnail: squared.png
 license: MIT License


### PR DESCRIPTION
http://anandu.info site seems to be squatted now and no longer has the demo.
