### PR TITLE
Update demo url of QckTheme

### DIFF
--- a/_posts/2015-01-24-qck-theme.markdown
+++ b/_posts/2015-01-24-qck-theme.markdown
@@ -4,7 +4,7 @@ title: QckTheme
 date: 2015-01-24
 homepage: https://github.com/qckanemoto/jekyll-qck-theme
 download: https://github.com/qckanemoto/jekyll-qck-theme/archive/master.zip
-demo: http://qckanemoto.github.io/
+demo: http://qckanemoto.github.io/jekyll-qck-theme/
 author: Takashi Kanemoto
 thumbnail: qck-theme.png
 license: MIT License


### PR DESCRIPTION
from http://qckanemoto.github.io/ (will be removed)
to http://qckanemoto.github.io/jekyll-qck-theme/