### PR TITLE
Updating two links for the documentation-theme-jekyll theme

### DIFF
--- a/_posts/2015-12-13-documentation-theme-jekyll.markdown
+++ b/_posts/2015-12-13-documentation-theme-jekyll.markdown
@@ -2,9 +2,9 @@
 layout: post
 title: Documentation Theme for Jekyll
 date: 2015-12-13 12:55
-homepage: http://idratherbewriting.com/documentation-theme-jekyll/mydoc/home.html
+homepage: http://idratherbewriting.com/documentation-theme-jekyll/
 download: https://github.com/tomjohnson1492/documentation-theme-jekyll/archive/gh-pages.zip
-demo: http://idratherbewriting.com/documentation-theme-jekyll/mydoc/home.html
+demo: http://idratherbewriting.com/documentation-theme-jekyll/
 author: tomjohnson1492
 thumbnail: documentation-theme-jekyll.png
 license: MIT License


### PR DESCRIPTION
I updated a couple of links in the documentation-theme-jekyll. The previous links were no longer valid.