### PR TITLE
_config.yml: Remove decommissioned rdiscount

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,6 @@ gems: [jekyll-paginate]
 highlighter: pygments
 paginate: 20
 
-markdown: rdiscount
-rdiscount:
-    extensions: ['smart']
+markdown: kramdown
 
 exclude: ['README.md', 'Gemfile.lock', 'Gemfile', 'Rakefile', 'vendor']


### PR DESCRIPTION
In May 2016, GitHub decommissioned rdiscount and force use of kramdown.

Closes https://github.com/mattvh/jekyllthemes/issues/494