### PR TITLE
resolved issue #606

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,7 +94,7 @@
         <div class="span5 copyright">
           Copyright &copy; {{ site.time | date: '%Y' }} Matt Harzewski. Powered by <a href="http://jekyllrb.com">Jekyll</a>.
           <br /><br />
-          <iframe src="http://ghbtns.com/github-btn.html?user=mattvh&repo=jekyllthemes&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
+          <iframe src="http://ghbtns.com/github-btn.html?user=mattvh&repo=jekyllthemes&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
           <iframe src="http://ghbtns.com/github-btn.html?user=mattvh&repo=jekyllthemes&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
           <br /><br />
         </div>


### PR DESCRIPTION
###  Fork number not shown
That is so good to see a huge star number but fork number is not being shown

<img width="473" alt="screen shot 2018-07-15 at 4 05 13 pm" src="https://user-images.githubusercontent.com/15800200/42733107-869df7f0-8849-11e8-96aa-734b028327f9.png">

This pull fixes this minor bug. @mattvh @junlulocky 

