### PR TITLE
Use plugins instead of deprecated gems

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: Insert tagline here
 
 permalink: /themes/:title/
 
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 
 highlighter: pygments
 paginate: 20


### PR DESCRIPTION
A warning appears when building project with newer jekyll version:
`Deprecation: The 'gems' configuration option has been renamed to 'plugins'.`

Background Info: 
The _gems_ tag is deprecated since 3.5. See: https://github.com/jekyll/jekyll/issues/4509