### PR TITLE
Update 2016-07-21-jekyll-simple.markdown / Repairing the broken link

### DIFF
--- a/_posts/2016-07-21-jekyll-simple.markdown
+++ b/_posts/2016-07-21-jekyll-simple.markdown
@@ -4,7 +4,7 @@ title: jekyll-simple
 date: 2016-07-21 19:01:03
 homepage: http://github.com/wild-flame/jekyll-simple
 download: https://github.com/wild-flame/jekyll-simple/archive/master.zip 
-demo: http://wildflame.me/jekyll-simple
+demo: http://wild-flame.github.io/jekyll-simple
 author: David Lin 
 thumbnail: jekyll-simple.png
 license: MIT License
@@ -17,4 +17,4 @@ Designed for mobile as well as tablet for the first, also a minimalized
 and `simple` theme which looks great on desktop. Considering a large
 number of people using cellphones to surf the internet.
 
-Click here to view the [demo](http://wildflame.me/jekyll-simple).
+Click here to view the [demo](http://wild-flame.github.io/jekyll-simple).


### PR DESCRIPTION
According to this issue https://github.com/wild-flame/jekyll-simple/issues/10, the live demo link for this theme is broken, just repair the link