### PR TITLE
Update 2017-08-15-materialize.markdown

### DIFF
--- a/_posts/2017-08-15-materialize.markdown
+++ b/_posts/2017-08-15-materialize.markdown
@@ -4,7 +4,7 @@ title: Jekyll Materialize
 date: 2017-08-15 00:08:00
 homepage: https://github.com/macrod68/jekyll-materialize-starter-template
 download: https://github.com/macrod68/jekyll-materialize-starter-template/archive/master.zip
-demo: http://jekyllmaterialize.panoramedia.it/
+demo: https://www.panoramedia.eu/jekyllmaterialize/
 author: Marco Damiani
 thumbnail: jekyllmaterialize.png
 license: MIT License


### PR DESCRIPTION
changed the url of the demo