### PR TITLE
Update the image URL and feature list for the Chirpy theme

### DIFF
--- a/_posts/2020-08-05-jekyll-theme-chirpy.md
+++ b/_posts/2020-08-05-jekyll-theme-chirpy.md
@@ -15,21 +15,23 @@ A minimal, sidebar, responsive web design Jekyll theme, focusing on text present
 
 [Live Demo »](https://cotes2020.github.io/chirpy-demo/)
 
-[![Devices Mockup](https://raw.githubusercontent.com/cotes2020/jekyll-theme-chirpy/master/assets/img/sample/devices-mockup.png)](https://cotes2020.github.io/chirpy-demo/)
+[![Devices Mockup](https://cdn.jsdelivr.net/gh/cotes2020/chirpy-images/commons/devices-mockup.png)](https://cotes2020.github.io/chirpy-demo/)
 
 ### Features
 
-* Pinned Posts
-* Configurable theme mode
-* Double-level Categories
-* Last modified date for posts
-* Table of Contents
-* Automatically recommend related posts
-* Syntax highlighting
-* Mathematical expressions
-* Search
-* Atom Feeds
-* Disqus Comments
-* Google Analytics
-* GA Pageviews reporting (Advanced)
-* SEO and Performance Optimization
+- Pinned Posts
+- Configurable theme mode
+- Double-level Categories
+- Last modified date for posts
+- Table of Contents
+- Automatically recommend related posts
+- Syntax highlighting
+- Mathematical expressions
+- Mermaid diagram & flowchart
+- Search
+- Atom Feeds
+- Disqus Comments
+- Google Analytics
+- GA Pageviews reporting (Advanced)
+- SEO and Performance Optimization
+


### PR DESCRIPTION

I fixed discarded image URLs in the repo [`jekyll-theme-chirpy`](https://github.com/cotes2020/jekyll-theme-chirpy). In addition, the introduction of the feature list is appended.