### PR TITLE
Update License reference for jekyl-podcaster

### DIFF
--- a/_posts/2020-07-20-jekyll-podcaster.markdown
+++ b/_posts/2020-07-20-jekyll-podcaster.markdown
@@ -7,7 +7,7 @@ download: https://github.com/PandaSekh/Jekyll-Podcaster/releases/latest
 demo: https://jekyll-podcaster.netlify.app/
 author: Alessio Franceschi
 thumbnail: podcaster.png
-license: MIT
+license: Custom license simliar to MIT with extra conditions
 license_link: https://github.com/PandaSekh/Jekyll-Podcaster/blob/master/LICENSE.txt
 ---
 


### PR DESCRIPTION
The theme linked has a custom license and not the OSI approved MIT license that I would expect when the license is stated as the MIT license here. 

I have also ticketed it upstream. https://github.com/PandaSekh/Jekyll-Podcaster/issues/9 however as it stands the license is not the MIT license.